### PR TITLE
Resolve KeyError with bmounts check

### DIFF
--- a/habitica/core.py
+++ b/habitica/core.py
@@ -248,7 +248,7 @@ def show_delta(before, after):
     amounts = aitems['mounts']
     bmounts = bitems['mounts']
     for mount in amounts:
-        if bmounts[mount] != amounts[mount] and amounts[mount] > 0:
+        if bmounts.get(mount, '') != amounts[mount] and amounts[mount] > 0:
             print("Grew %s" % (mount))
 
 


### PR DESCRIPTION
Fix this traceback:

Feeding 1 CottonCandyBlue to CottonCandyBlue Hedgehog
Traceback (most recent call last):
  File "/home/bdmurray/.local/bin/habitica", line 6, in <module>
    exec(compile(open(**file**).read(), **file**, 'exec'))
  File "/home/bdmurray/source-trees/habitica-cli/habitica/bin/habitica", line 15, in <module>
    habitica.cli()
  File "/home/bdmurray/source-trees/habitica-cli/habitica/habitica/core.py", line 449, in cli
    show_delta(before_user, user)
  File "/home/bdmurray/source-trees/habitica-cli/habitica/habitica/core.py", line 251, in show_delta
    if bmounts[mount] != amounts[mount] and amounts[mount] > 0:
KeyError: u'Hedgehog-CottonCandyBlue'
