### PR TITLE
Reorder Quest info in status output and include damage estimate(?)

### DIFF
--- a/habitica/core.py
+++ b/habitica/core.py
@@ -799,6 +799,9 @@ def cli():
                 party.get('quest').get('active')):
 
             quest_key = party['quest']['key']
+            # wtf‽
+            # party['quest']['progress'] != user['party']['quest']['progress']
+            quest_damage = user['party']['quest']['progress']['up']
 
             if cache.get(SECTION_CACHE_QUEST, 'quest_key') != quest_key:
                 # we're on a new quest, update quest key
@@ -838,10 +841,11 @@ def cli():
             else:
                 quest_progress = party['quest']['progress']['hp']
 
-            quest = '%s/%s "%s"' % (
+            quest = '"%s" %s/%s (-%d)' % (
+                    cache.get(SECTION_CACHE_QUEST, 'quest_title'),
                     str(int(quest_progress)),
                     cache.get(SECTION_CACHE_QUEST, 'quest_max'),
-                    cache.get(SECTION_CACHE_QUEST, 'quest_title'))
+                    quest_damage)
 
         # prepare and print status strings
         title = 'Level %d %s' % (stats['lvl'], stats['class'].capitalize())


### PR DESCRIPTION
I say its an estimate because that's what they say on oldgods.net, however it's right there in the API so might be accurate.
